### PR TITLE
API change for performance improvement (remove max_num_events)

### DIFF
--- a/examples/bl_api_expers.py
+++ b/examples/bl_api_expers.py
@@ -46,7 +46,6 @@ def fetch_ecosystem_metadata():
                 'event_types': ['create_ecosystem'],
                 'ecosystem_uuid': ecosystem_uuid,
                 'sequence_number_offset': 0,
-                'max_num_events': 10,
             }
 
             data['ecosystem_event_requests'].append(event_request)
@@ -91,7 +90,6 @@ def fetch_course_events(target_course_uuid):
 
     with open('output/course_{}.txt'.format(target_course_uuid), 'w') as fd:
         current_sequence_number = 0
-        max_num_events = 100
 
         while True:
             data = {
@@ -111,7 +109,6 @@ def fetch_course_events(target_course_uuid):
                         ],
                         'course_uuid': target_course_uuid,
                         'sequence_number_offset': current_sequence_number,
-                        'max_num_events': max_num_events,
                     },
                 ],
             }

--- a/sparfa_server/api.py
+++ b/sparfa_server/api.py
@@ -19,7 +19,6 @@ blapi = BiglearnApi(api_token=api_token, sched_token=sched_token)
 
 def create_course_event_request(course_uuid,
                                 offset,
-                                max_events,
                                 request_uuid=None):
     data = {
         'course_event_requests': [],
@@ -43,7 +42,6 @@ def create_course_event_request(course_uuid,
         ],
         'course_uuid': course_uuid,
         'sequence_number_offset': offset,
-        'max_num_events': max_events
     }
 
     data['course_event_requests'].append(event_request)
@@ -63,7 +61,6 @@ def create_ecosystem_event_request(ecosystem_uuid, request_uuid=None):
         'event_types': ['create_ecosystem'],
         'ecosystem_uuid': ecosystem_uuid,
         'sequence_number_offset': 0,
-        'max_num_events': 10,
     }
 
     data['ecosystem_event_requests'].append(event_request)
@@ -80,8 +77,8 @@ def fetch_course_uuids(course_uuids=None):
     return [uuid['uuid'] for uuid in course_metadatas['course_responses']]
 
 
-def fetch_course_event_requests(course_uuid, offset=0, max_events=100):
-    payload = create_course_event_request(course_uuid, offset, max_events)
+def fetch_course_event_requests(course_uuid, offset=0):
+    payload = create_course_event_request(course_uuid, offset)
 
     course_event_reqs = blapi.fetch_course_event_requests(payload)
 
@@ -210,4 +207,3 @@ def update_clue_calcs(alg_name, ecosystem_uuid, calc_uuid, clue_min,
     }
     response = blapi.update_clue_calcs(payload)
     return response['clue_calculation_update_responses'][0]
-

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -20,7 +20,6 @@ class TestBiglearnApi(UnitHelper):
         request_uuid = str(uuid.uuid4())
         course_uuid = str(uuid.uuid4())
         offset = 0
-        max_events = 100
 
         event_request = {
             'course_event_requests': [
@@ -38,8 +37,7 @@ class TestBiglearnApi(UnitHelper):
                         'record_response'
                     ],
                     'course_uuid': course_uuid,
-                    'sequence_number_offset': offset,
-                    'max_num_events': max_events
+                    'sequence_number_offset': offset
 
                 }
             ]
@@ -47,7 +45,6 @@ class TestBiglearnApi(UnitHelper):
 
         data = create_course_event_request(course_uuid,
                                            offset,
-                                           max_events,
                                            request_uuid)
         assert data == event_request
 
@@ -62,7 +59,6 @@ class TestBiglearnApi(UnitHelper):
                     'event_types': ['create_ecosystem'],
                     'ecosystem_uuid': ecosystem_uuid,
                     'sequence_number_offset': 0,
-                    'max_num_events': 10,
                 }
             ]
         }
@@ -81,8 +77,7 @@ class TestBiglearnApi(UnitHelper):
     def test_fetch_course_event_requests(self):
         course_uuid = str(uuid.uuid4())
         offset = 10
-        max_events = 100
-        payload = create_course_event_request(course_uuid, offset, max_events)
+        payload = create_course_event_request(course_uuid, offset)
         url = build_url('api', 'fetch_course_events')
         self.instance.fetch_course_event_requests(payload)
         self.post_called_with(url, data=payload)


### PR DESCRIPTION
I removed max_num_events from the event endpoints so biglearn-api can decide how many events to send based on the size of the data field.

DON'T MERGE THIS UNTIL https://github.com/openstax/biglearn-api/pull/50 (and https://github.com/openstax/biglearn-scheduler/pull/15) ARE MERGED.