### PR TITLE
create scripts for setup and test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ target/
 # Celery files
 /celerybeat.pid
 /celerybeat-schedule
+
+
+# Virtualenv
+/.venv/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,8 @@ cache:
 
 # command to install dependencies
 
-install:
-  - pip install --process-dependency-links .[dev]
-  - pip install codecov
-
 script:
-  - python setup.py test
+  - ./script/test
 
 after_success:
   - codecov

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+brew "postgresql"
+brew "python3"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Python tasks used to support Biglearn and conduct calculations.
 
 ## Get Started
 
+# Quick setup (OSX)
+
+You can just run `./script/setup` (assuming you have [Homebrew](http://brew.sh/) and docker installed).
+
+
 ### Installing the system dependencies on OS X
 
 This section describes how to install the dependencies on Mac OS X.
@@ -82,6 +87,8 @@ Docker and Docker Compose. This should work on any OS that docker can be install
 8. Set environmental variables. See `.env.example` for required variables to be set.
 
 ## Dev Server
+
+(or just run `./script/start`)
 
 The dev server runs the celery worker and the beat process to start all periodic tasks.
 The tasks are the loader tasks and the calculations. Make sure you have the database and RabbitMQ services running.
@@ -163,5 +170,3 @@ b9287092c49f -> cbac16278e4f (head), added biglearn knowledge models
 ```
 
 This shows the base started at `b9287092c49f` which is a version named "initial schema" which is followed by `cbac16278e4f` which is a version labeled "added biglearn knowledge models".
-
-

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Resolve all dependencies that the application requires to run.
+# From https://github.com/github/scripts-to-rule-them-all/blob/master/script/bootstrap
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
+  >&2 echo "==> Updating Homebrew…"
+  brew update
+
+  brew bundle check >/dev/null 2>&1  || {
+    >&2 echo "==> Installing Homebrew dependencies…"
+    brew bundle
+  }
+fi
+
+# Check that docker is installed
+[[ $(which docker-compose) ]] || (echo "Error: docker-compose is not installed" && exit 1)

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+./script/bootstrap
+
+echo "==> Creating python Virtualenv"
+make venv
+
+echo "==> Activating the virtualenv"
+source .venv/bin/activate
+
+echo "==> Initializing the database"
+make initdb

--- a/script/start
+++ b/script/start
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Activating the virtualenv"
+source .venv/bin/activate
+
+echo "==> Starting server"
+sparf server

--- a/script/test
+++ b/script/test
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Start up the virtualenv if not running in travis-ci
+
+[[ "${VIRTUAL_ENV}" ]] || source .venv/bin/activate
+
+echo "==> Installing test packages and code coverage"
+pip install --process-dependency-links .[dev]
+pip install codecov
+
+
+echo "==> Running Tests"
+python setup.py test


### PR DESCRIPTION
This should simplify the process for devs starting up the server.

Getting up and running should end up being:

```sh
# install homebrew and docker manually

./script/setup
./script/test
```

# TODO

- [ ] fix the `sparfa-algs=0.0.1` error:

```
Collecting six==1.10.0 (from biglearn-sparfa-server==0.0.1)
  Using cached six-1.10.0-py2.py3-none-any.whl
Collecting sparfa-algs==0.0.1 (from biglearn-sparfa-server==0.0.1)
  Could not find a version that satisfies the requirement sparfa-algs==0.0.1 (from biglearn-sparfa-server==0.0.1) (from versions: )
No matching distribution found for sparfa-algs==0.0.1 (from biglearn-sparfa-server==0.0.1)
make: *** [venv] Error 1
```

- [ ] handle reinitializing the database. I currently get this error:

```
==> Initializing the database
psql -h 127.0.0.1 -p 5432 -d postgres -U postgres -c "DROP DATABASE IF EXISTS bl_sparfa_server"
psql: could not connect to server: Connection refused
	Is the server running on host "127.0.0.1" and accepting
	TCP/IP connections on port 5432?
make: *** [initdb] Error 2
```

