### PR TITLE
Speed up exercise calculations

### DIFF
--- a/sparfa_server/biglearn/clients.py
+++ b/sparfa_server/biglearn/clients.py
@@ -1,5 +1,4 @@
 from logging import getLogger
-from json import dumps
 from requests import Session
 
 from .. import __version__

--- a/sparfa_server/tasks/calcs.py
+++ b/sparfa_server/tasks/calcs.py
@@ -148,6 +148,7 @@ def calculate_exercises():
                     )
 
             response_dicts_by_calculation_uuid = defaultdict(list)
+            # Beware that uuid columns return UUID objects (not strings) when using from_statement()
             for result in session.query('calculation_uuid', Response).from_statement(text(dedent("""
                 SELECT "values"."calculation_uuid", "responses".*
                 FROM "responses" INNER JOIN (VALUES {}) AS "values"
@@ -155,9 +156,11 @@ def calculate_exercises():
                     ON "responses"."student_uuid" = "values"."student_uuid"
                         AND "responses"."ecosystem_uuid" = "values"."ecosystem_uuid"
             """.format(', '.join(calculation_values))).strip())).all():
-                calc_uuid = result.calculation_uuid
+                calc_uuid = str(result.calculation_uuid)
                 response = result.Response
-                if response.exercise_uuid in known_exercise_uuids_by_calculation_uuid[calc_uuid]:
+                if str(
+                    response.exercise_uuid
+                ) in known_exercise_uuids_by_calculation_uuid[calc_uuid]:
                     response_dicts_by_calculation_uuid[calc_uuid].append(response.dict_for_algs)
 
             exercise_calculation_requests = []

--- a/tests/unit/tasks/test_calcs.py
+++ b/tests/unit/tasks/test_calcs.py
@@ -10,7 +10,12 @@ from sparfa_server.tasks.calcs import (calculate_ecosystem_matrices,
 
 
 def test_calculate_ecosystem_matrices(transaction):
-    ecosystem_1 = Ecosystem(uuid=str(uuid4()), metadata_sequence_number=0, sequence_number=1)
+    ecosystem_1 = Ecosystem(
+      uuid=str(uuid4()),
+      metadata_sequence_number=0,
+      sequence_number=1,
+      last_ecosystem_matrix_update_calculation_uuid=str(uuid4())
+    )
 
     calculation_uuid = str(uuid4())
     ecosystem_matrix_updates = [{


### PR DESCRIPTION
By not sending all the exercise uuids to the database when loading responses and instead filtering the responses on the client side.